### PR TITLE
fixed npm scripts issue on windows and install missed glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "src/index.js",
   "scripts": {
     "postinstall": "jspm install",
-    "start": "./node_modules/gulp/bin/gulp.js start",
-    "start:prod": "npm run build && ./node_modules/gulp/bin/gulp.js server",
-    "test": "./node_modules/gulp/bin/gulp.js test",
-    "test:watch": "./node_modules/gulp/bin/gulp.js test:watch",
-    "build": "./node_modules/gulp/bin/gulp.js build",
-    "gulp": "./node_modules/gulp/bin/gulp.js"
+    "start": "gulp start",
+    "start:prod": "npm run build && gulp server",
+    "test": "gulp test",
+    "test:watch": "gulp test:watch",
+    "build": "gulp build",
+    "gulp": "gulp"
   },
   "repository": {
     "type": "git",
@@ -32,6 +32,7 @@
     "browser-sync": "2.11.1",
     "chai": "3.5.0",
     "del": "2.2.0",
+    "glob": "^7.0.3",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-changed": "1.3.0",
     "gulp-html-replace": "1.5.5",


### PR DESCRIPTION
I had troubles for run npm start on windows. So I replace the ./node_modules/bin/gulp.js for gulp from the scripts section in the package.json file. I also had troubles with the copy task of gulp, so I installed it and save to package.json
